### PR TITLE
deploy.rbのエラー改修

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,4 +34,16 @@ namespace :deploy do
   task :restart do
     invoke 'unicorn:restart'
   end
+
+  desc 'upload master.key'
+  task :upload do
+    on roles(:app) do |host|
+      if test "[ ! -d #{shared_path}/config ]"
+        execute "mkdir -p #{shared_path}/config"
+      end
+      upload!('config/master.key', "#{shared_path}/config/master.key")
+    end
+  end
+  before :starting, 'deploy:upload'
+  after :finishing, 'deploy:cleanup'
 end


### PR DESCRIPTION
## What
ファイルが参照できていない為エラーが発生した為、修正を行う。
## Why
自動デプロイ中にエラーが発生した為。