### PR TITLE
見積書_コメントの非同期実装

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,5 +1,5 @@
-$(function(){
-  function buildHTML(comment){
+$(function() {
+  function buildHTML(comment) {
     var html =
       `<div class="comment__list--all">
         <li class="comment__list--text">
@@ -12,7 +12,7 @@ $(function(){
     return html;
   }
 
-  $('#document__comment').on('submit', function(e){
+  $('#document__comment').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action');
@@ -24,12 +24,17 @@ $(function(){
       processData: false,
       contentType: false
     })
-    .done(function(data){
+
+    .done(function(data) {
       var html = buildHTML(data);
       $('.block__text--wide').append(html);
        $('form')[0].reset();
        $('.block__text--wide').animate({ scrollTop: $('.block__text--wide')[0].scrollHeight});
        $(".submit-btn").prop('disabled', false);
     })
+
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
   });
 });

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,4 +1,17 @@
 $(function(){
+  function buildHTML(comment){
+    var html =
+      `<div class="comment__list--all">
+        <li class="comment__list--text">
+          ${comment.comment}
+        </li>
+        <li class="comment__list--date">
+          ${comment.created_at}
+        </li>
+      </div>`
+    return html;
+  }
+
   $('#document__comment').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -10,6 +23,11 @@ $(function(){
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.block__text--wide').append(html);
+       $('form')[0].reset();
     })
   });
 });

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -29,6 +29,7 @@ $(function(){
       $('.block__text--wide').append(html);
        $('form')[0].reset();
        $('.block__text--wide').animate({ scrollTop: $('.block__text--wide')[0].scrollHeight});
+       $(".submit-btn").prop('disabled', false);
     })
   });
 });

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#document__comment').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  });
+});

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -28,6 +28,7 @@ $(function(){
       var html = buildHTML(data);
       $('.block__text--wide').append(html);
        $('form')[0].reset();
+       $('.block__text--wide').animate({ scrollTop: $('.block__text--wide')[0].scrollHeight});
     })
   });
 });

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,9 +1,9 @@
 class CommentsController < ApplicationController
   def create_quotation
-    comment = Comment.new(comment_quotation_params)
-    if comment.save
+    @comment = Comment.new(comment_quotation_params)
+    if @comment.save
       respond_to do |format|
-        format.json_qu
+        format.json
       end
     else
       redirect_to quotation_comment_path

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,7 @@ class CommentsController < ApplicationController
     comment = Comment.new(comment_quotation_params)
     if comment.save
       respond_to do |format|
-        format.json
+        format.json_qu
       end
     else
       redirect_to quotation_comment_path

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,7 +2,9 @@ class CommentsController < ApplicationController
   def create_quotation
     comment = Comment.new(comment_quotation_params)
     if comment.save
-      redirect_to "/quotations/#{comment.quotation.id}"
+      respond_to do |format|
+        format.json
+      end
     else
       redirect_to quotation_comment_path
     end

--- a/app/views/comments/create_quotation.json.jbuilder
+++ b/app/views/comments/create_quotation.json.jbuilder
@@ -1,0 +1,2 @@
+json.comment @comment.comment
+json.created_at @comment.created_at.strftime("%Y年%m月%d日 %H時%M分")

--- a/app/views/comments/create_quotation.json.jbuilder
+++ b/app/views/comments/create_quotation.json.jbuilder
@@ -1,2 +1,2 @@
-json.comment @comment.comment
-json.created_at @comment.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.comment    @comment.comment
+json.created_at @comment.created_at.strftime('%Y/%m/%d')

--- a/app/views/quotations/show.html.haml
+++ b/app/views/quotations/show.html.haml
@@ -30,7 +30,7 @@
           = @quotation.created_at.strftime('%Y/%m/%d')
       .text__container--block
         .block__label コメントする
-        = form_with(model: [@quotation, @comment], url: create_quotation_quotation_comment_path(@quotation)) do |f|
+        = form_with(model: [@quotation, @comment], url: create_quotation_quotation_comment_path(@quotation), id: "document__comment") do |f|
           = f.text_area :comment, placeholder: "（例）4月17日に◯◯へ提出予定", class: "wide__area"
           = f.submit "SEND"
 

--- a/app/views/quotations/show.html.haml
+++ b/app/views/quotations/show.html.haml
@@ -32,7 +32,7 @@
         .block__label コメントする
         = form_with(model: [@quotation, @comment], url: create_quotation_quotation_comment_path(@quotation), id: "document__comment", local: true) do |f|
           = f.text_area :comment, placeholder: "（例）4月17日に◯◯へ提出予定", class: "wide__area"
-          = f.submit "SEND"
+          = f.submit "SEND", class: "submit-btn"
 
       .text__container--block
         .block__label コメント一覧

--- a/app/views/quotations/show.html.haml
+++ b/app/views/quotations/show.html.haml
@@ -30,7 +30,7 @@
           = @quotation.created_at.strftime('%Y/%m/%d')
       .text__container--block
         .block__label コメントする
-        = form_with(model: [@quotation, @comment], url: create_quotation_quotation_comment_path(@quotation), id: "document__comment") do |f|
+        = form_with(model: [@quotation, @comment], url: create_quotation_quotation_comment_path(@quotation), id: "document__comment", local: true) do |f|
           = f.text_area :comment, placeholder: "（例）4月17日に◯◯へ提出予定", class: "wide__area"
           = f.submit "SEND"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module Customa
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
+    config.time_zone = 'Tokyo'
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
 


### PR DESCRIPTION
## What
見積書のコメント機能を非同期に変更する。
## Why
turbolinksを削除した為、手動で非同期にする必要があった為。
またユーザーはリアルタイムでコメントを投稿、確認までできるようにする為。